### PR TITLE
Add YouTube 20.20.3 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Just wanted to give you an update about uYouEnhanced. I’m not fully leaving or
 
 I do my best to fix stuff when issues pop up, but it sometimes usually doesn’t work out. I do even suggest workarounds, but they might not work perfectly, especially with the latest YouTube version changes.
 
-But as of writing this, I’d recommend using uYouEnhanced with YouTube version v20.05.4 (the ipa version I use).
+But as of writing this, I’d recommend using uYouEnhanced with YouTube version v20.20.3 (the ipa version I use).
 Thanks for understanding!
 
 And thanks to qnblackcat, PoomSmart & other developers allowing me to expand this fork from where it is today!
@@ -315,7 +315,7 @@ And thanks to qnblackcat, PoomSmart & other developers allowing me to expand thi
 
 | **Tweaks/App** | **Developer** | **Version** | **Open source** |
 | - | - | :-: | :-:  |
-| **YouTube** | Google Inc | 20.10.4 | ✖︎ |
+| **YouTube** | Google Inc | 20.20.3 | ✖︎ |
 | [uYou](https://github.com/MiRO92/uYou-for-YouTube) | [MiRO92](https://twitter.com/miro92) | 3.0.4 | ✖︎ |
 | **OpenYoutubeAndShorts** | [CrossiDev-Studio](https://github.com/CrossiDev-Studio) | 1.0 | [✔︎](https://github.com/CrossiDev-Studio/OpenYoutubeAndShorts) |
 | **iSponsorBlock** | [Galactic-Dev](https://github.com/Galactic-Dev) | 1.2.9 | [✔︎](https://github.com/Galactic-Dev/iSponsorBlock) |

--- a/Sources/uYouPlusSettings.xm
+++ b/Sources/uYouPlusSettings.xm
@@ -848,6 +848,8 @@ NSString *cacheDescription = [NSString stringWithFormat:@"%@", GetCacheSize()];
                     return @"v19.02.1";
                 case 84:
                     return @"v19.01.1";
+                case 85:
+                    return @"v20.20.3";
                 default:
                     return @"v20.23.3";
             }
@@ -938,7 +940,8 @@ NSString *cacheDescription = [NSString stringWithFormat:@"%@", GetCacheSize()];
                 SPOOFER_VERSION(@"v19.04.3", 81),
                 SPOOFER_VERSION(@"v19.03.2", 82),
                 SPOOFER_VERSION(@"v19.02.1", 83),
-                SPOOFER_VERSION(@"v19.01.1", 84)
+                SPOOFER_VERSION(@"v19.01.1", 84),
+                SPOOFER_VERSION(@"v20.20.3", 85)
             ];
             YTSettingsPickerViewController *picker = [[%c(YTSettingsPickerViewController) alloc] initWithNavTitle:LOC(@"VERSION_SPOOFER_SELECTOR") pickerSectionTitle:nil rows:rows selectedItemIndex:appVersionSpoofer() parentResponder:[self parentResponder]];
             [settingsViewController pushViewController:picker];

--- a/Sources/uYouPlusVersionSpoofer.xm
+++ b/Sources/uYouPlusVersionSpoofer.xm
@@ -90,7 +90,8 @@ static VersionMapping versionMappings[] = {
     {81, @"19.04.3"},
     {82, @"19.03.2"},
     {83, @"19.02.1"},
-    {84, @"19.01.1"}
+    {84, @"19.01.1"},
+    {85, @"20.20.3"}
 };
 
 static int appVersionSpoofer() {


### PR DESCRIPTION
## Summary
- update README to reflect YouTube v20.20.3
- allow version spoofing to v20.20.3

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a055d7060832c8201b8410b8625be